### PR TITLE
add the sequential config field

### DIFF
--- a/args.go
+++ b/args.go
@@ -11,8 +11,9 @@ type args struct {
 }
 
 type Rule struct {
-	Pattern  string   `yaml:"pattern"`
-	Commands []string `yaml:"commands"`
+	Pattern    string   `yaml:"pattern"`
+	Commands   []string `yaml:"commands"`
+	Sequential bool     `yaml:"sequential"`
 }
 
 type CommandsFile struct {

--- a/commands.yaml
+++ b/commands.yaml
@@ -1,7 +1,16 @@
 write:
   - pattern: "**/*.go"
     commands:
-     - echo "write event"
+      - echo "1"
+      - echo "2"
+      - echo "3"
+      - echo "4"
+      - echo "5"
+      - echo "6"
+      - echo "7"
+#     - go build -o exec ./...
+#     - ./exec
+    sequential: true
 rename:
   - pattern: "*"
     commands:


### PR DESCRIPTION
this PR addresses part of #8, which is adding support for a field in the config to control how the commands should run, sequentially or concurrently, each pattern will has its own field so that the users can specify which commands to run concurrently and which commands to run sequentially.