### PR TITLE
add support for on_success and on_failure config fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,10 +3,13 @@ package main
 import "gopkg.in/yaml.v3"
 
 type Rule struct {
-	Pattern    string   `yaml:"pattern"`
 	Commands   []string `yaml:"commands"`
+	OnSuccess  []string `yaml:"on_success"`
+	OnFailure  []string `yaml:"on_failure"`
+	Pattern    string   `yaml:"pattern"`
 	Sequential bool     `yaml:"sequential"`
 }
+
 
 type CommandsFile struct {
 	Write  []Rule `yaml:"write"`


### PR DESCRIPTION
example config file:

```yaml
write:
  - pattern: "**/*.go"
    commands:
     - go build -o exec ./...
     - ./exec
    sequential: true
    on_success:
      - echo "commands are executed successfully"
    on_failure:
      - echo "commands failed to be executed successfully"
...
```